### PR TITLE
Section on SNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Example of how that might be implemented:
 
 ### Always use HTTPS
 
-Any new API should use &mdash; and ideally require &mdash; [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure) (using TLS/SSL). HTTPS provides:
+Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure) (using TLS/SSL). HTTPS provides:
 
 * **Security**. The contents of the request are encrypted across the Internet.
 * **Authenticity**. A stronger guarantee that a client is communicating with the real API.


### PR DESCRIPTION
At @seanherron's [suggestion](https://github.com/18F/api-standards/pull/27#issuecomment-47024698), I added a section on [Server Name Indication](http://en.wikipedia.org/wiki/Server_Name_Indication). This is particularly meaningful after the experience of attempting SNI support for [openFDA](https://open.fda.gov/).

@seanherron, feel free to merge this yourself if it merits your :+1:, or edit it in-place on the `sni` branch.
