### PR TITLE
Rename example resource to 'articles'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Common ways to do this include a mailing list, or a [dedicated developer blog](h
 An "endpoint" is a combination of two things:
 
 * The verb (e.g. `GET` or `POST`)
-* The URL path (e.g. `/posts`)
+* The URL path (e.g. `/articles`)
 
 Information can be passed to an endpoint in either of two ways:
 


### PR DESCRIPTION
Changed example resource from '/posts' to '/articles'. This is to avoid any potential confusion between the POST http verb (which appears nearby) and the contrived resource example of [blog] posts.
