### PR TITLE
Recommend consistency over `under_score` for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ General JSON guidelines:
 
 * Responses should be **a JSON object** (not an array). Using an array to return results limits the ability to include metadata about results, and limits the API's ability to add additional top-level keys in the future.
 * **Don't use unpredictable keys**. Parsing a JSON response where keys are unpredictable (e.g. derived from data) is difficult, and adds friction for clients.
-* **Use `under_score` case for keys**. Different languages use different case conventions. JSON uses `under_score`, not `camelCase`.
+* **Use consistent case for keys**. Whether you use `under_score` or `CamelCase` for your API keys, make sure you are consistent.
 
 ### Use a consistent date format
 


### PR DESCRIPTION
* Fixes https://github.com/18F/api-standards/issues/40