### PR TITLE
Add request body to ways information can be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ An "endpoint" is a combination of two things:
 * The verb (e.g. `GET` or `POST`)
 * The URL path (e.g. `/articles`)
 
-Information can be passed to an endpoint in either of two ways:
+Information can be passed to an endpoint in any combination of three ways:
 
 * The URL query string (e.g. `?year=2014`)
+* The request body (e.g. in a form `POST`, `year=2014`)
 * HTTP headers (e.g. `X-Api-Key: my-key`)
 
 When people say "RESTful" nowadays, they really mean designing simple, intuitive endpoints that represent unique functions in the API.


### PR DESCRIPTION
In a document that is high quality and quite thorough, I felt there was one imprecise word and one omission here.
1. Ambiguity of the word "either".  In casual non-technical usage, we often use this word to me "one or the other, not both".  Since header params and the query params are not exclusive, I think changing this to "any" helps clarify that.
2. Submitting data via a request body param is clearly a distinct third method for passing information to an endpoint.  (It's unclear to me why it wouldn't be included.)
