### PR TITLE
changing example URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Generally speaking:
 
 Some examples of these principles in action:
 
-* [FBOpen API documentation](https://18f.github.io/fbopen/)
+* [FEC API documentation](https://api.open.fec.gov/developers/)
 * [OpenFDA example query](https://open.fda.gov/api/reference/#example-query)
 * [Sunlight Congress API methods](https://sunlightlabs.github.io/congress/#using-the-api)
 


### PR DESCRIPTION
from FBOpen (no longer live) to FEC